### PR TITLE
Allow parsing of requests with no OAuth headers.

### DIFF
--- a/src/oauth_uri.erl
+++ b/src/oauth_uri.erl
@@ -31,7 +31,7 @@ params_to_header_string(Params) ->
   intercalate(", ", [concat([encode(K), "=\"", encode(V), "\""]) || {K, V} <- Params]).
 
 params_from_header_string(String) ->
-  [param_from_header_string(Param) || Param <- re:split(String, ",\\s*", [{return, list}])].
+  [param_from_header_string(Param) || Param <- re:split(String, ",\\s*", [{return, list}]), Param =/= ""].
 
 param_from_header_string(Param) ->
   [Key, QuotedValue] = string:tokens(Param, "="),


### PR DESCRIPTION
This must be a leftover from the improvement that jasondavies did for the CouchDB integration of erlang_oauth.

Sending this upstream so we don't have to maintain a separate fork.
