### PR TITLE
http_uri:parse(URI) now returns {ok,{Scheme,...}} in R15B

### DIFF
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -228,6 +228,8 @@ header_param_decode(Param) ->
 
 uri_normalize(URI) ->
   case http_uri:parse(URI) of
+    {ok, {Scheme, UserInfo, Host, Port, Path, _Query}} -> % R15B
+      uri_normalize(Scheme, UserInfo, string:to_lower(Host), Port, [Path]);
     {Scheme, UserInfo, Host, Port, Path, _Query} ->
       uri_normalize(Scheme, UserInfo, string:to_lower(Host), Port, [Path]);
     Else ->


### PR DESCRIPTION
To make it work with the latest version, Erlang/OTP R15B, I added two lines:

```
diff --git a/src/oauth.erl b/src/oauth.erl
index 5fc563e..d7257ad 100644
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -228,6 +228,8 @@ header_param_decode(Param) ->

 uri_normalize(URI) ->
   case http_uri:parse(URI) of
+    {ok, {Scheme, UserInfo, Host, Port, Path, _Query}} -> % R15B
+      uri_normalize(Scheme, UserInfo, string:to_lower(Host), Port, [Path]);
     {Scheme, UserInfo, Host, Port, Path, _Query} ->
       uri_normalize(Scheme, UserInfo, string:to_lower(Host), Port, [Path]);
     Else ->
```

Best regards,
naoyat
