### PR TITLE
ignore oauth.beam

### DIFF
--- a/ebin/.gitignore
+++ b/ebin/.gitignore
@@ -1,0 +1,1 @@
+oauth.beam


### PR DESCRIPTION
I added a simple `.gitignore` file to the `ebin` folder, so that git could ignore `oauth.beam`.
