### PR TITLE
replaced deprecated crypto:sha_mac/2 with crypto:hmac/3

### DIFF
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -263,7 +263,7 @@ uri_join(Values) ->
   uri_join(Values, "&").
 
 uri_join(Values, Separator) ->
-  string:join([uri_encode(Value) || Value <- Values], Separator).
+  string:join(lists:map(fun uri_encode/1, Values), Separator).
 
 intercalate(Sep, Xs) ->
   lists:concat(intersperse(Sep, Xs)).


### PR DESCRIPTION
`crypto:sha_mac/2` is deprecated and will be removed in in a future Erlang release.
